### PR TITLE
Update CI image from circleci/node:10 to cimg/node:lts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,8 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:10
+      # https://circleci.com/developer/images/image/cimg/node
+      - image: cimg/node:lts
     working_directory: ~/repo
     steps:
       - checkout


### PR DESCRIPTION
I noticed a warning saying that we are using a legacy docker image. It linked to this documentation:

https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034

I figured we might as well also update to the latest node LTS version, which is currently node v20.