### PR TITLE
Set pnpm minimumReleaseAge to 2 days to match Dependabot

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,7 +13,12 @@ savePrefix: ''
 dedupePeerDependents: true
 allowBuilds:
   sharp: true
+
+# Match dependabot npm cooldown (default-days: 2 in .github/dependabot.yml)
+minimumReleaseAge: 2880
+
 minimumReleaseAgeExclude:
+  - release-with-ease
   - minimatch@3.1.3
   - minimatch@3.1.4
   - brace-expansion@1.1.13


### PR DESCRIPTION
## Summary
- Set `minimumReleaseAge` to 2880 minutes (2 days) in `pnpm-workspace.yaml` to align with Dependabot npm cooldown.
- Adds `release-with-ease` to `minimumReleaseAgeExclude`.

## Test plan
- [ ] `pnpm install` succeeds

Made with [Cursor](https://cursor.com)